### PR TITLE
Dynamic certificate ARN

### DIFF
--- a/applications/web_app/fullstack/zeroday-fullstack/template/README.md
+++ b/applications/web_app/fullstack/zeroday-fullstack/template/README.md
@@ -33,9 +33,8 @@ The Fullstack template is a fullstack project using Node and React. The template
 
 - **React + Redux Frontend**
 
-  - Webpack 4 + refactored common config
-  - React Router 4
-  - Less templating with production minify
+  - Webpack 5 + refactored common config
+  - React Router 5
   - Building minified nginx image for Docker
 
 - **Docker Compose**
@@ -49,8 +48,13 @@ The Fullstack template is a fullstack project using Node and React. The template
 
 - **Jenkins**
 
-  - Everything build and tested using Docker
-  - Slack Notifications
+  - Everything built and tested using Docker
+  - Trivy security scanning
+
+- **GitHub Actions**
+  - Everything built and tested using Docker
+  - Trivy security scanning
+  - Slack notifications
 
 ---
 
@@ -88,7 +92,8 @@ For production mode you need to use the production configuration file:
 
 ### Prepare database
 
-    Install postgresql: 
+Install postgresql:
+
     https://www.postgresql.org/download/
 
     psql -c "CREATE ROLE demo WITH CREATEDB LOGIN PASSWORD 'demo'"
@@ -101,19 +106,21 @@ Add this line to your .env:
 
 ### Backend
 
-    Run these commands in the /backend directory:
+Run these commands in the /backend directory:
+
+    npm install
+    npm start
+
+The backend will run on port `9000`
+
+### Frontend
+
+Run these commands in the /frontend directory:
 
     npm install
     npm start
 
 The frontend will run on port `8000`
-
-### Frontend
-
-    Run these commands in the /frontend directory:
-
-    npm install
-    npm start
 
 ---
 
@@ -125,8 +132,8 @@ To use editorconfig, [download plugin for your IDE](https://editorconfig.org/#do
 
 Run eslint in Docker container
 
-docker-compose run backend-dev sh -c "npm run lint"
-docker-compose run frontend-dev sh -c "npm run lint"
+    docker-compose run backend-dev sh -c "npm run lint"
+    docker-compose run frontend-dev sh -c "npm run lint"
 
 Run `npm run lint` in backend and frontend directories to check the linting locally.
 
@@ -158,6 +165,6 @@ Jenkins can be set up automatically with the executor script named "GitHub Jenki
 
 ## Teardown of resources after automatic or manual deployment
 
-The following list includes the resources, which are to be removed. Delete resources selectively if required.
+The following list includes the resources which are to be removed. Delete resources selectively if required.
 
 1. Delete Jenkins pipeline

--- a/deployment/AWS/EKS/Fullstack EKS/docs/requirements.md
+++ b/deployment/AWS/EKS/Fullstack EKS/docs/requirements.md
@@ -1,0 +1,4 @@
+Requirements for sucessfully deploying with this template:
+- Access key & secret for an IAM user with the permissions listed in [deploy-aws-policy.json](../template/deploy-aws-policy.json)
+- A certificate in ACM valid for the deployment URL. (ie. *.xyz.example.com for app.xyz.example.com)
+- A Route53 hosted zone for the deployment URL domain.

--- a/deployment/AWS/EKS/Fullstack EKS/docs/requirements.md
+++ b/deployment/AWS/EKS/Fullstack EKS/docs/requirements.md
@@ -1,4 +1,8 @@
-Requirements for sucessfully deploying with this template:
-- Access key & secret for an IAM user with the permissions listed in [deploy-aws-policy.json](../template/deploy-aws-policy.json)
-- A certificate in ACM valid for the deployment URL. (ie. *.xyz.example.com for app.xyz.example.com)
-- A Route53 hosted zone for the deployment URL domain.
+# Requirements for sucessfully deploying with this template:
+* Access key & secret for an IAM user with the permissions listed in [deploy-aws-policy.json](../template/deploy-aws-policy.json).
+* A certificate in ACM valid for the deployment URL. (ie. *.xyz.example.com for app.xyz.example.com)
+* A Route53 hosted zone for the deployment URL domain.
+# Application template compatibility
+* Currently compatible with zeroday fullstack application template & react w/ REST python.
+* For other app templates, modify build-deploy.sh.j2 to conditionally include the right docker compose command.
+* For other app templates, frontend must run on port 8000 and backend on port 9000.

--- a/deployment/AWS/EKS/Fullstack EKS/template/deploy-aws-policy.json
+++ b/deployment/AWS/EKS/Fullstack EKS/template/deploy-aws-policy.json
@@ -65,7 +65,8 @@
                 "route53:*",
                 "sts:GetCallerIdentity",
                 "ecr:GetRepositoryPolicy",
-                "ecr:PutReplicationConfiguration"
+                "ecr:PutReplicationConfiguration",
+                "acm:ListCertificates"
             ],
             "Resource": "*"
         },

--- a/deployment/AWS/EKS/Fullstack EKS/template/helm/ingress-nginx/09-controller-service.yaml.template
+++ b/deployment/AWS/EKS/Fullstack EKS/template/helm/ingress-nginx/09-controller-service.yaml.template
@@ -5,7 +5,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:eu-north-1:413441202289:certificate/a6e63e83-e22d-4d81-84df-5bccb4299eb3
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: %CERTNAME%
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
     service.beta.kubernetes.io/aws-load-balancer-type: elb
   labels:

--- a/deployment/AWS/EKS/Fullstack EKS/template/setup-aws.sh
+++ b/deployment/AWS/EKS/Fullstack EKS/template/setup-aws.sh
@@ -103,6 +103,21 @@ done
 
 set -x
 
+
+certificateDomain=$(echo $DEPLOY_PUBLIC_ADDRESS|cut -f2- -d.)
+
+certificateArn=$(aws acm list-certificates --query CertificateSummaryList[].[CertificateArn,DomainName]  --output text | grep $certificateDomain | cut -f1)
+
+if [ -z "$certificateArn" ]
+then
+      echo "Could not find certificateArn . Check that you have a certificate in ACM for the public deployment address. "
+      exit(1)
+fi
+
+echo $certificateArn
+
+sed "s#%CERTNAME%#$certificateArn#g" ./helm/ingress-nginx/09-controller-service.yaml.template > ./helm/ingress-nginx/09-controller-service.yaml
+
 if [ "$DEPLOY_DOCKER_REGISTRY_TYPE" == 'ecr' ]
 then
     aws ecr describe-repositories --repository-name $DEPLOY_PROJECT_NAME/$DEPLOY_MODE/frontend >> /dev/null && \

--- a/deployment/AWS/EKS/Fullstack EKS/template/setup-aws.sh
+++ b/deployment/AWS/EKS/Fullstack EKS/template/setup-aws.sh
@@ -114,8 +114,6 @@ then
       exit 1
 fi
 
-echo $certificateArn
-
 sed "s#%CERTNAME%#$certificateArn#g" ./helm/ingress-nginx/09-controller-service.yaml.template > ./helm/ingress-nginx/09-controller-service.yaml
 
 if [ "$DEPLOY_DOCKER_REGISTRY_TYPE" == 'ecr' ]

--- a/deployment/AWS/EKS/Fullstack EKS/template/setup-aws.sh
+++ b/deployment/AWS/EKS/Fullstack EKS/template/setup-aws.sh
@@ -111,7 +111,7 @@ certificateArn=$(aws acm list-certificates --query CertificateSummaryList[].[Cer
 if [ -z "$certificateArn" ]
 then
       echo "Could not find certificateArn . Check that you have a certificate in ACM for the public deployment address. "
-      exit(1)
+      exit 1
 fi
 
 echo $certificateArn


### PR DESCRIPTION
Removing the hardcoded certificate ARN and instead get it dynamically from AWS.

Also adding the file `deployment/[...]/docs/requirements.md`, that contains the pre-requisites for deploying a project to AWS. The idea is that at some point Sprout will be able to show this in the UI. 